### PR TITLE
Migrate navigation to go_router and go_router_builder

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_engineer_codecheck/l10n/app_localizations.dart';
-import 'package:flutter_engineer_codecheck/search_repo/screens/repo_search_screen.dart';
+import 'package:flutter_engineer_codecheck/router/router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 void main() {
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'GitHub Repo Search',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
@@ -24,7 +24,7 @@ class MyApp extends StatelessWidget {
       ),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: const RepoSearchScreen(),
+      routerConfig: router,
     );
   }
 }

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_engineer_codecheck/search_repo/screens/repo_detail_screen.dart';
+import 'package:flutter_engineer_codecheck/search_repo/screens/repo_search_screen.dart';
+import 'package:go_router/go_router.dart';
+
+part 'router.g.dart';
+
+@TypedGoRoute<SearchRoute>(
+  path: '/',
+  routes: [
+    TypedGoRoute<DetailRoute>(path: 'detail/:owner/:repo'),
+  ],
+)
+@immutable
+class SearchRoute extends GoRouteData with $SearchRoute {
+  const SearchRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const RepoSearchScreen();
+}
+
+@immutable
+class DetailRoute extends GoRouteData with $DetailRoute {
+  const DetailRoute({required this.owner, required this.repo});
+
+  final String owner;
+  final String repo;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      RepoDetailScreen(owner: owner, repo: repo);
+}
+
+final router = GoRouter(
+  routes: $appRoutes,
+);

--- a/lib/router/router.g.dart
+++ b/lib/router/router.g.dart
@@ -1,0 +1,71 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'router.dart';
+
+// **************************************************************************
+// GoRouterGenerator
+// **************************************************************************
+
+List<RouteBase> get $appRoutes => [
+      $searchRoute,
+    ];
+
+RouteBase get $searchRoute => GoRouteData.$route(
+      path: '/',
+      factory: $SearchRoute._fromState,
+      routes: [
+        GoRouteData.$route(
+          path: 'detail/:owner/:repo',
+          factory: $DetailRoute._fromState,
+        ),
+      ],
+    );
+
+mixin $SearchRoute on GoRouteData {
+  static SearchRoute _fromState(GoRouterState state) => const SearchRoute();
+
+  @override
+  String get location => GoRouteData.$location(
+        '/',
+      );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $DetailRoute on GoRouteData {
+  static DetailRoute _fromState(GoRouterState state) => DetailRoute(
+        owner: state.pathParameters['owner']!,
+        repo: state.pathParameters['repo']!,
+      );
+
+  DetailRoute get _self => this as DetailRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+        '/detail/${Uri.encodeComponent(_self.owner)}/${Uri.encodeComponent(_self.repo)}',
+      );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}

--- a/lib/search_repo/screens/repo_search_screen.dart
+++ b/lib/search_repo/screens/repo_search_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_engineer_codecheck/router/router.dart';
 import 'package:flutter_engineer_codecheck/search_repo/core/l10n/github_repo_api_exception_l10n.dart';
 import 'package:flutter_engineer_codecheck/search_repo/providers/repo_search_provider.dart';
 import 'package:flutter_engineer_codecheck/search_repo/repository/github_repo_api_exception.dart';
 import 'package:flutter_engineer_codecheck/search_repo/repository/search_repo_model.dart';
-import 'package:flutter_engineer_codecheck/search_repo/screens/repo_detail_screen.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class RepoSearchScreen extends ConsumerWidget {
@@ -198,16 +198,8 @@ class _RepoListItem extends StatelessWidget {
         ],
       ),
       isThreeLine: false,
-      onTap: () {
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (_) => RepoDetailScreen(
-              owner: item.owner.login,
-              repo: item.name,
-            ),
-          ),
-        );
-      },
+      onTap: () =>
+          DetailRoute(owner: item.owner.login, repo: item.name).push(context),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "91.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: f4ad0fea5f102201015c9aae9d93bc02f75dd9491529a8c21f88d17a8523d44c
+      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
       url: "https://pub.dev"
     source: hosted
-    version: "7.6.0"
+    version: "8.4.1"
   archive:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
+      sha256: "7174c5d84b0fed00a1f5e7543597b35d67560465ae3d909f0889b8b20419d5e3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "3.0.1"
   build_config:
     dependency: transitive
     description:
@@ -77,26 +77,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "99d3980049739a985cf9b21f30881f46db3ebc62c5b8d5e60e27440876b1ba1e"
+      sha256: "82730bf3d9043366ba8c02e4add05842a10739899520a6a22ddbd22d333bd5bb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "3.0.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "74691599a5bc750dc96a6b4bfd48f7d9d66453eab04c7f4063134800d6a5c573"
+      sha256: "32c6b3d172f1f46b7c4df6bc4a47b8d88afb9e505dd4ace4af80b3c37e89832b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.14"
+    version: "2.6.1"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
+      sha256: "4b188774b369104ad96c0e4ca2471e5162f0566ce277771b179bed5eabf2d048"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "9.2.1"
   built_collection:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
+      sha256: "6ae8a6435a8c6520c7077b107e77f1fb4ba7009633259a4d49a8afd8e7efc5e9"
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.3"
+    version: "8.12.4"
   characters:
     dependency: transitive
     description:
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
+      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
   dio:
     dependency: "direct main"
     description:
@@ -288,6 +288,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -304,6 +309,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: "7974313e217a7771557add6ff2238acb63f635317c35fa590d348fb238f00896"
+      url: "https://pub.dev"
+    source: hosted
+    version: "17.1.0"
+  go_router_builder:
+    dependency: "direct dev"
+    description:
+      name: go_router_builder
+      sha256: "135648d2febcf6e45d87ad12f4dbcf2d0fb46eb1aa14722c0a42c7a60f02ac55"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.0"
   graphs:
     dependency: transitive
     description:
@@ -360,14 +381,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.1"
   json_annotation:
     dependency: "direct main"
     description:
@@ -380,10 +393,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
+      sha256: c5b2ee75210a0f263c6c7b9eeea80553dbae96ea1bf57f02484e806a3ffdffa3
       url: "https://pub.dev"
     source: hosted
-    version: "6.9.5"
+    version: "6.11.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -553,18 +566,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: "1d562a3c1f713904ebbed50d2760217fd8a51ca170ac4b05b0db490699dbac17"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "4.2.0"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
+      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.5"
+    version: "1.3.8"
   source_span:
     dependency: transitive
     description:
@@ -718,5 +731,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  go_router: ^17.1.0
   hooks_riverpod: ^2.6.1
   json_annotation: ^4.8.1
   riverpod_annotation: ^2.3.0
@@ -24,6 +25,7 @@ dev_dependencies:
   flutter_lints: ">=3.0.1 <6.0.0"
   flutter_test:
     sdk: flutter
+  go_router_builder: ^4.2.0
   json_serializable: ^6.7.1
 
 flutter:


### PR DESCRIPTION
## Summary

- Add `go_router` and `go_router_builder` packages as the official navigation solution
- Introduce type-safe `SearchRoute` (`/`) and `DetailRoute` (`/detail/:owner/:repo`) via `GoRouteData` with code generation
- Replace `Navigator.push` / `MaterialPageRoute` with `DetailRoute(...).push(context)`
- Switch `MaterialApp` to `MaterialApp.router` with the generated `GoRouter` instance

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — all tests passed

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)